### PR TITLE
add aggregated view and edit roles for crd

### DIFF
--- a/templates/rbac/aggregated-role.yaml
+++ b/templates/rbac/aggregated-role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubediag-view
+  labels:
+    app: {{ include "kubediag-helm.name" . }}
+    app.kubernetes.io/name: {{ include "kubediag-helm.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["diagnosis.kubediag.org"]
+    resources: ["diagnoses", "diagnoses/status", "operations", "operations/status", "operationsets", "operationsets/status", "triggers"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubediag-edit
+  labels:
+    app: {{ include "kubediag-helm.name" . }}
+    app.kubernetes.io/name: {{ include "kubediag-helm.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["diagnosis.kubediag.org"]
+resources: ["diagnoses", "diagnoses/status", "operations", "operations/status", "operationsets", "operationsets/status", "triggers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]


### PR DESCRIPTION
This change aims to aggregate kubediag's clusterrole into default [user-facing clusterroles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) installed by kubernetes.