### PR TITLE
Fix erroneous syntax in aggregated-role.yaml

### DIFF
--- a/templates/rbac/aggregated-role.yaml
+++ b/templates/rbac/aggregated-role.yaml
@@ -10,9 +10,9 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-  - apiGroups: ["diagnosis.kubediag.org"]
-    resources: ["diagnoses", "diagnoses/status", "operations", "operations/status", "operationsets", "operationsets/status", "triggers"]
-    verbs: ["get", "list", "watch"]
+- apiGroups: ["diagnosis.kubediag.org"]
+  resources: ["diagnoses", "diagnoses/status", "operations", "operations/status", "operationsets", "operationsets/status", "triggers"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -25,6 +25,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-  - apiGroups: ["diagnosis.kubediag.org"]
-resources: ["diagnoses", "diagnoses/status", "operations", "operations/status", "operationsets", "operationsets/status", "triggers"]
-    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+- apiGroups: ["diagnosis.kubediag.org"]
+  resources: ["diagnoses", "diagnoses/status", "operations", "operations/status", "operationsets", "operationsets/status", "triggers"]
+  verbs: ["create", "delete", "deletecollection", "patch", "update"]


### PR DESCRIPTION
Fix error: YAML parse error on kubediag-helm/templates/rbac/aggregated-role.yaml: error converting YAML to JSON: yaml: line 13: did not find expected key.