### PR TITLE
introduce chart values to disable service&serviceMonitor for prometheus (by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ helm repo update
 helm install kubediag kubediag/kubediag-helm --create-namespace --namespace kubediag
 ```
 
+Prometheus operator related resources are disabled by default. To enable related monitors, specify the '--set' flag when install kubediag (Before this step, make sure you have deployed prometheus operator):
+
+```bash
+helm install kubediag kubediag/kubediag-helm --create-namespace --namespace kubediag --set prometheus.serviceMonitor.selfMonitor=true
+```
+
 Check the status of KubeDiag by running the command:
 
 ```bash

--- a/templates/prometheus/kubediag-agent-metrics-monitor.yaml
+++ b/templates/prometheus/kubediag-agent-metrics-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.serviceMonitor.selfMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -17,3 +18,4 @@ spec:
     matchLabels:
       control-plane: kubediag
       mode: agent
+{{- end }}

--- a/templates/prometheus/kubediag-agent-metrics-service.yaml
+++ b/templates/prometheus/kubediag-agent-metrics-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prometheus.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     control-plane: kubediag
     mode: agent
   type: ClusterIP
+{{- end }}

--- a/templates/prometheus/kubediag-master-metrics-monitor.yaml
+++ b/templates/prometheus/kubediag-master-metrics-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.serviceMonitor.selfMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -17,3 +18,4 @@ spec:
     matchLabels:
       control-plane: kubediag
       mode: master
+{{- end }}

--- a/templates/prometheus/kubediag-master-metrics-service.yaml
+++ b/templates/prometheus/kubediag-master-metrics-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prometheus.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     control-plane: kubediag
     mode: master
   type: ClusterIP
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -99,3 +99,19 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+prometheus:
+  enabled: true
+  annotations: {}
+  ## Configuration for Prometheus service
+  service:
+    annotations: {}
+    labels: {}
+    clusterIP: ""
+  ## Configuration for Prometheus serviceMonitor  
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    interval: ""
+    selfMonitor: false
+    ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
+    scheme: ""


### PR DESCRIPTION
Fix #5 
The lack of prometheus operator may cause failure when install kubediag.
Prometheus operator related resources can be enabled or disabled by chart values.